### PR TITLE
fix(ci): pin npm@11 in publish workflow to avoid EBADENGINE on node 22.21.0

### DIFF
--- a/.github/workflows/.publish-npm.yml
+++ b/.github/workflows/.publish-npm.yml
@@ -49,7 +49,9 @@ jobs:
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
             echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            # pin npm@11 (>= the 11.5.1 oidc floor); npm@latest is 12.x, whose node
+            # engine floor (^22.22.2) exceeds the runner's node 22.21.0 and fails EBADENGINE
+            npm install -g npm@11
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi


### PR DESCRIPTION
fix(ci): pin npm@11 in publish workflow to avoid EBADENGINE on node 22.21.0

- the publish oidc-compat guard ran npm install -g npm@latest when npm < 11.5.1
- npm@latest rolled to 12.x, whose node engine floor (^22.22.2) exceeds the github
  runner node (22.21.0), so the upgrade failed EBADENGINE and blocked npm publish
- pin npm@11 instead: it satisfies the 11.5.1 oidc floor and runs on node 22.21.0
- pre-existing infra defect (publish.yml identical to main), surfaced by the v0.13.0
  release; flag upstream declapract-typescript-ehmpathy to pin repo-wide

---
🐢🌊 surfed in by seaturtle[bot]